### PR TITLE
iam: update policies with _user/_attach

### DIFF
--- a/terraform/module-req/codecommit.tf
+++ b/terraform/module-req/codecommit.tf
@@ -70,9 +70,14 @@ data "aws_iam_policy_document" "codecommit_readonly" {
 }
 
 resource "aws_iam_user_policy" "codecommit_readonly" {
-  count = "${var.create_codecommit_repository == "1" ? 1 : 0}"
+  count       = "${var.create_codecommit_repository == "1" ? 1 : 0}"
+  name        = "codecommit-stacks-readonly${var.suffix}"
+  description = "A policy to allow readonly access to CodeCommit"
+  policy      = "${data.aws_iam_policy_document.codecommit_readonly.json}"
+}
 
-  name   = "codecommit-stacks-readonly${var.suffix}"
-  user   = "${aws_iam_user.codecommit_readonly.name}"
-  policy = "${data.aws_iam_policy_document.codecommit_readonly.json}"
+resource "aws_iam_user_policy_attachement" "codecommit_readonly_attachement" {
+  count      = "${var.create_codecommit_repository == "1" ? 1 : 0}"
+  user       = "${aws_iam_user.codecommit_readonly.name}"
+  policy_arn = "${aws_iam_policy.codecommit_readonly.arn}"
 }

--- a/terraform/module-req/infra_user.tf
+++ b/terraform/module-req/infra_user.tf
@@ -11,17 +11,8 @@ resource "aws_iam_access_key" "infra" {
   user = "${aws_iam_user.infra.name}"
 }
 
-resource "aws_iam_policy_attachment" "infra_administrator_access" {
-  count = "${var.create_infra_user ? 1 : 0}"
-
-  name       = "infra-AdministratorAccess${var.suffix}"
-  users      = ["${aws_iam_user.infra.name}"]
-  roles      = ["admin"]
-  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
-
-  lifecycle {
-    ignore_changes = [
-      "groups",
-    ]
-  }
+resource "aws_iam_user_policy_attachment" "infra_user_admin_attach" {
+    count      = "${var.create_infra_user ? 1 : 0}"
+    user       = "${aws_iam_user.infra.name}"
+    policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }


### PR DESCRIPTION
To avoid messing up some other already setup policies, it is better to
use the dedicated 'aws_iam_{user,group,role}_policy_attachement' syntax,
rather than the deprecated policy_attachement.