### PR TITLE
.cycloid.yml: update typo in description

### DIFF
--- a/.cycloid.yml
+++ b/.cycloid.yml
@@ -2,7 +2,7 @@
 name: 'Amazon requirements'
 canonical: 'aws-requirements'
 status: 'public'
-description: 'Create optionnaly an S3 bucket for terraform, IAM user as admin and codecommit repository.'
+description: 'Create optionally an S3 bucket for terraform, IAM user as admin and codecommit repository.'
 keywords:
   - 's3'
   - 'iam'


### PR DESCRIPTION
Optionally is spelled with 2 l not 2 n.